### PR TITLE
[压缩相邻消息]支持prompt分割、自定义提取深度、Dx及以上占位符

### DIFF
--- a/src/酒馆助手/压缩相邻消息/Panel.vue
+++ b/src/酒馆助手/压缩相邻消息/Panel.vue
@@ -21,6 +21,24 @@
         <input v-model="settings.seperator.value" class="text_pole flex1 wide100p" type="text" autocomplete="off" />
       </div>
 
+      <div class="flex-container flexFlowColumn">
+        <div style="display: flex; align-items: center; gap: 8px">
+          <span>遇到分割符时停止合并</span>
+          <input v-model="settings.split_seperator.enabled" type="checkbox" style="margin: 0 4px 0 0" />
+        </div>
+      </div>
+
+      <div v-if="settings.split_seperator.enabled" class="flex-container flexFlowColumn">
+        <label>分割符 (支持正则)</label>
+        <input
+          v-model="settings.split_seperator.pattern"
+          class="text_pole flex1 wide100p"
+          type="text"
+          placeholder="[---] 或 /分割符正则/"
+          autocomplete="off"
+        />
+      </div>
+
       <hr />
 
       <div class="flex-container flexFlowColumn">
@@ -30,10 +48,22 @@
           <i
             class="fa-solid fa-circle-question fa-sm note-link-span"
             style="cursor: pointer"
-            title="将注入到聊天深度的系统消息按照原有顺序移动到聊天记录的末尾，而不是保持在原来的深度位置。这可以确保系统消息不会干扰聊天记录的连续性。"
+            title="将注入到聊天深度的系统消息按照原有顺序移动到聊天记录的末尾，而不是保持在原来的深度位置。"
             @click="showDepthHelp"
           />
         </div>
+      </div>
+
+      <div v-if="settings.put_system_injection_after_chat_history" class="flex-container flexFlowColumn">
+        <label>深度阈值</label>
+        <input
+          v-model.number="settings.system_depth"
+          class="text_pole"
+          type="number"
+          min="1"
+          max="9998"
+          style="width: 80px"
+        />
       </div>
 
       <hr />
@@ -134,10 +164,11 @@ const system_prefix_input = useEscapedNewlineModel(toRef(settings.value.on_chat_
 const system_suffix_input = useEscapedNewlineModel(toRef(settings.value.on_chat_history, 'system_suffix'));
 
 function showDepthHelp() {
+  const depth = settings.value.system_depth;
   SillyTavern.callGenericPopup(
     `<p>按照<a href="https://discord.com/channels/1134557553011998840/1413538722078785576">一些预设作者和角色卡作者的说法</a>, Gemini 和 Claude 不同, 不必将条目插入聊天记录中, 插入其中反而会干扰聊天记录的连续性, 重要条目应该都插入到 D0.</p>
      <p>但玩家依旧可能使用 Claude、GPT 等游玩, 而对它们还是需要用 D4 等深度的.</p>
-     <p>因此本脚本提供了这个选项: 勾选这个选项, D10 以下的条目将会被移动到 D0 位置, 而 D10 及以上条目将会被移动到 D9999 位置; 而关闭这个选项系统消息将会保持原有深度.</p>
+     <p>因此本脚本提供了这个选项: 勾选这个选项, D${depth} 以下的条目将会被移动到 D0 位置, 而 D${depth} 及以上条目将会被移动到 D9999 位置; 而关闭这个选项系统消息将会保持原有深度.</p>
      <p>这个选项虽然已经不用角色卡作者自行将条目全设置为 D0, 但仍很需要角色卡适配; 如果角色详情等会随剧情发展的设定放在了深度条目, 则勾选这个选项容易使角色固化</p>`,
     SillyTavern.POPUP_TYPE.TEXT,
     '',

--- a/src/酒馆助手/压缩相邻消息/settings.ts
+++ b/src/酒馆助手/压缩相邻消息/settings.ts
@@ -26,7 +26,14 @@ export const Settings = z.object({
       }
       return data;
     }),
+  split_seperator: z
+    .object({
+      enabled: z.boolean().default(false),
+      pattern: z.string().default('[---]'),
+    })
+    .prefault({}),
   put_system_injection_after_chat_history: z.boolean().default(false),
+  system_depth: z.number().int().min(1).max(9998).default(10),
   on_chat_history: z
     .object({
       type: z.enum(['mixin', 'seperate', 'squash']).default('squash'),


### PR DESCRIPTION
## 更新内容

### 1. 新增功能: Prompt分割

新增"遇到分割符时停止合并"选项。当消息内容匹配分割符时,即使角色相同也不会合并到同一条消息中。

- 支持字符串或正则表达式 (如 `[---]` 或 `/分割符正则/`)
- 分割符本身会从消息中移除

### 2. 新增功能: 自定义提取深度

深度阈值现在可以自定义 (原来固定为 D10)。

- 范围: 1-9998
- Dx 以下的条目移动到 D0 位置
- Dx 及以上的条目移动到 D9999 位置

### 3. 新增功能: Dx及以上条目占位符

在提示词中填入占位符 (默认 `{{ABOVE_DX}}`), Dx 及以上的系统条目将替换该占位符, 而非移动到 D9999 位置。

**行为说明:**
- 如果提示词中存在占位符: Dx及以上的系统消息替换到占位符位置
- 如果提示词中不存在占位符: 按原逻辑移动到 D9999
- 无论占位符是否使用: Dx以下的系统消息都移动到聊天记录之后
- 如果没有 Dx 及以上的条目, 占位符将被删除
- 留空占位符字段可禁用此功能

## 修改文件

- `settings.ts` - 新增 `split_seperator`、`system_depth`、`above_dx_placeholder` 设置
- `squash.ts` - 新增 `replacePlaceholder` 函数, 修改 `squashMessageByRole` 支持分割符, 深度改为动态
- `Panel.vue` - 新增对应 UI 控件和帮助说明

## 测试

已测试通过